### PR TITLE
uvで宣言された依存関係をrequirementsに反映

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+charset-normalizer==3.4.4
+pillow==12.1.0
+reportlab==4.4.9


### PR DESCRIPTION
README で利用を案内されていて、#5  とかでも使いそうなのでuv.lockを見て中身入れておきました
```shell
$ pip install reportlab==4.4.9
$ pip freeze >> requirements.txt
```