### PR TITLE
[提案]対象のフォルダに画像がないときはエラーとする

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -37,6 +37,8 @@ def main():
 
     input_dir = Path(args.input_dir)
     mapping = {image.stem: str(image) for image in sorted(input_dir.glob("*.png"))}
+    if len(mapping) <= 0:
+        raise FileNotFoundError(f"{input_dir}の中にpngファイルがありません")
 
     create_layout_pdf(
         mapping,


### PR DESCRIPTION
## 事象
画像フォルダが空のときに `python cli.py  create`を実行すると0ページのpdfファイルが出力される
```shell 
~/Documents/git-dir/qr-print-helper develop2*
qr-print-helper ❯ ls -la images
drwxr-xr-x yume_yu staff  96 B Fri Feb  6 00:41:43 2026  .
drwxr-xr-x yume_yu staff 480 B Fri Feb  6 00:52:26 2026  ..
.rw-r--r-- yume_yu staff   0 B Thu Feb  5 23:51:27 2026  .gitkeep

~/Documents/git-dir/qr-print-helper develop2*
qr-print-helper ❯ python cli.py create

~/Documents/git-dir/qr-print-helper develop2*
qr-print-helper ❯ file labels.pdf
labels.pdf: PDF document, version 1.3, 0 pages
```

## 修正提案
指定されたフォルダのpngファイルが1つもなかった場合はFileNotFoundErrorをraiseする