### PR TITLE
deploy.ymlのYAML構文エラーを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,5 +129,5 @@ jobs:
             qr-print-helper-windows/*.zip
             qr-print-helper-macos/*.zip
             qr-print-helper-installer/*.exe
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `softprops/action-gh-release`ステップの`env:`が`with:`ブロック内にインデントされていたYAML構文エラーを修正
- エラー: `(Line: 133, Col: 13): A mapping was not expected`

## Changes
- `.github/workflows/deploy.yml` - `env:`のインデントを`with:`と同階層に修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)