### PR TITLE
chore: vuchvu/repository-templateのCopier更新を適用

### DIFF
--- a/.claude/skills/pr-release/SKILL.md
+++ b/.claude/skills/pr-release/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: pr-release
+description: 「本リリース」と言われたら使うスキル。developブランチからmainブランチへのPRを作成する。
+---
+
+# PR Release Skill
+
+developブランチ → mainブランチへのPR作成を行う。マージは人間が行う。
+
+---
+
+### Step 1: 事前確認
+
+```bash
+gh auth status
+
+# develop→main のPRが既に存在する場合はエラーになるので確認
+gh pr list --base main --head develop
+```
+
+既存PRがあれば、そのURLをユーザーに伝えて止まる。
+
+### Step 2: mainに未反映の仮リリースPRを自動収集
+
+mainにまだマージされていない仮リリース（develop向けPR）のタイトルを収集する：
+
+```bash
+# mainにマージされた最新のPRのマージ日時を取得
+LAST_RELEASE_DATE=$(gh pr list --base main --state merged --limit 1 --json mergedAt \
+  | jq -r '.[0].mergedAt // empty')
+
+# それ以降にdevelopにマージされたPRを取得
+if [ -n "$LAST_RELEASE_DATE" ]; then
+  gh pr list --base develop --state merged --json title,mergedAt \
+    | jq -r --arg since "$LAST_RELEASE_DATE" \
+      '[.[] | select(.mergedAt > $since)] | sort_by(.mergedAt) | .[] | "- " + .title'
+else
+  gh pr list --base develop --state merged --json title,mergedAt \
+    | jq -r 'sort_by(.mergedAt) | .[] | "- " + .title'
+fi
+```
+
+取得したタイトルでPR説明文を自動生成し、ユーザーに確認してもらう：
+
+```
+## リリース内容
+- <仮リリース1のタイトル>
+- <仮リリース2のタイトル>
+- ...
+```
+
+### Step 3: PR作成（ユーザー入力なし）
+
+```bash
+BODY="## リリース内容
+- <自動生成した箇条書き>"
+
+gh pr create \
+  --base main \
+  --head develop \
+  --title "Release: $(date +%Y-%m-%d)" \
+  --body "$BODY"
+
+gh pr view --json url -q .url
+```
+
+マージはしない。URLをユーザーに伝えて完了。
+
+トラブル発生時は `references/troubleshooting.md` を参照。

--- a/.claude/skills/pr-release/references/troubleshooting.md
+++ b/.claude/skills/pr-release/references/troubleshooting.md
@@ -1,0 +1,25 @@
+# トラブルシューティング
+
+## jq が未インストールの場合
+
+`jq` コマンドが使えない場合は、以下で代替する：
+
+```bash
+gh pr list --base develop --state merged --json title,mergedAt
+```
+
+出力されたJSONを手動で確認してPR本文を作成する。
+
+## リポジトリ名の確認
+
+```bash
+gh repo view --json nameWithOwner
+```
+
+## develop→main の既存PRが既にある場合
+
+```bash
+gh pr list --base main --head develop
+```
+
+既存PRのURLをユーザーに伝えて、そちらを更新するか確認する。

--- a/.claude/skills/pr-staging/SKILL.md
+++ b/.claude/skills/pr-staging/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: pr-staging
+description: 「仮リリース」と言われたら使うスキル。featureブランチからdevelopブランチへのPRを作成・squash mergeする。
+---
+
+# PR Staging Skill
+
+(feat or fixブランチでなければ作成 →) feat or fixブランチ → developブランチへのPR作成＆squash mergeを行う。
+
+---
+
+### Step 1: 事前確認
+
+```bash
+git status
+git branch --show-current
+gh auth status
+```
+
+- 未コミットの変更があればユーザーに確認する
+- `gh` が未認証なら止まって伝える
+
+### Step 2: cliff.toml の検出
+
+```bash
+test -f cliff.toml && echo "cliff.toml found"
+```
+
+`cliff.toml` が存在する場合、このリポジトリはconventional commitsでリリースノートを自動生成している。
+未プッシュコミットを確認し、形式に沿っているかユーザーに案内する：
+
+```bash
+git log origin/develop..HEAD --oneline
+```
+
+conventional commitsの形式については `references/conventional-commits.md` を参照。
+形式が不正なコミットがあれば `git commit --amend` や `git rebase -i` での修正を促す。（強制はしない）
+
+### Step 3: PRテンプレートからPR情報を生成
+
+```
+タイトル:
+
+## 概要
+<!-- 何をなぜ変更したか -->
+
+## 変更内容
+
+-
+-
+
+## 確認事項
+- [ ] テスト追加・更新済み
+- [ ] 動作確認済み
+```
+
+### Step 4: PR作成
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+TITLE="<タイトル>"
+BODY="<本文>"
+
+gh pr create \
+  --base develop \
+  --head "$CURRENT_BRANCH" \
+  --title "$TITLE" \
+  --body "$BODY"
+
+gh pr view --json url -q .url
+```
+
+### Step 5: マージ確認 → squash merge
+
+ユーザーにマージ確認を取り、OKであれば：
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+トラブル発生時は `references/troubleshooting.md` を参照。

--- a/.claude/skills/pr-staging/references/conventional-commits.md
+++ b/.claude/skills/pr-staging/references/conventional-commits.md
@@ -1,0 +1,27 @@
+# Conventional Commits 形式
+
+## prefix一覧
+
+| prefix      | 用途             |
+| ----------- | ---------------- |
+| `feat:`     | 新機能           |
+| `fix:`      | バグ修正         |
+| `docs:`     | ドキュメント     |
+| `refactor:` | リファクタリング |
+| `chore:`    | その他の変更     |
+
+スコープがある場合は `feat(scope): message` の形式。
+
+## 修正方法
+
+直前のコミットを修正：
+
+```bash
+git commit --amend
+```
+
+複数コミットをまとめて修正：
+
+```bash
+git rebase -i origin/develop
+```

--- a/.claude/skills/pr-staging/references/troubleshooting.md
+++ b/.claude/skills/pr-staging/references/troubleshooting.md
@@ -1,0 +1,30 @@
+# トラブルシューティング
+
+## gh が未認証の場合
+
+```bash
+gh auth login
+```
+
+## developブランチへの同一PRが既に存在する場合
+
+```bash
+gh pr list --base develop --head $(git branch --show-current)
+```
+
+既存PRのURLをユーザーに伝えて、そちらを更新するか確認する。
+
+## squash merge 後にブランチ削除が失敗した場合
+
+```bash
+git branch -d <branch-name>
+git push origin --delete <branch-name>
+```
+
+## origin/develop が存在しない場合
+
+```bash
+git fetch origin develop
+```
+
+fetchしてから再試行する。

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; do NOT edit
-_commit: a7e4bc8
+_commit: d4aceea
 _src_path: gh:vuchvu/repository-template
 project_name: qr-print-helper
 project_specific_agents: '## PRラベル


### PR DESCRIPTION
## 概要

vuchvu/repository-template の最新コミット（d4aceea）に追従するため Copier で更新を適用した。

## 変更内容

- `.copier-answers.yml` のコミットハッシュを更新（a7e4bc8 → d4aceea）
- `.claude/skills/pr-staging/SKILL.md` を追加
- `.claude/skills/pr-staging/references/conventional-commits.md` を追加
- `.claude/skills/pr-staging/references/troubleshooting.md` を追加
- `.claude/skills/pr-release/SKILL.md` を追加
- `.claude/skills/pr-release/references/troubleshooting.md` を追加

## 確認事項
- [ ] テスト追加・更新済み
- [ ] 動作確認済み