### PR TITLE
ci: GitHub ActionsのコミットSHAを固定し、無効なNuitkaキャッシュを削除

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version-file: .python-version
           enable-cache: true
@@ -32,17 +32,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra build
 
-      - name: Cache Nuitka
-        uses: actions/cache@v4
-        with:
-          path: .nuitka-cache
-          key: nuitka-${{ runner.os }}-${{ hashFiles('gui.py', 'core/**/*.py') }}
-          restore-keys: nuitka-${{ runner.os }}-
-
       - name: Build with Nuitka (Windows)
         if: runner.os == 'Windows'
-        env:
-          NUITKA_CACHE_DIR: .nuitka-cache
         run: >-
           uv run python -m nuitka gui.py
           --standalone --onefile --enable-plugin=tk-inter
@@ -54,8 +45,6 @@ jobs:
 
       - name: Build with Nuitka (macOS)
         if: runner.os == 'macOS'
-        env:
-          NUITKA_CACHE_DIR: .nuitka-cache
         run: >-
           uv run python -m nuitka gui.py
           --standalone --onefile --enable-plugin=tk-inter
@@ -90,14 +79,14 @@ jobs:
         shell: bash
 
       - name: Upload zip artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: qr-print-helper-${{ matrix.suffix }}
           path: qr-print-helper-${{ github.ref_name }}-${{ matrix.suffix }}.zip
 
       - name: Upload installer artifact
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: qr-print-helper-installer
           path: build/qr-print-helper-${{ github.ref_name }}-installer.exe
@@ -108,21 +97,21 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
 
       - name: Generate Changelog
         id: changelog
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
         with:
           config: cliff.toml
           args: --latest --strip all
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           body: ${{ steps.changelog.outputs.changelog }}
           files: |

--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for version label
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const labels = context.payload.pull_request.labels.map(label => label.name);

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           token: ${{ secrets.PUSH_TOKEN }}
 
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install uv
         if: steps.bump.outputs.type != ''
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Bump version and tag
         if: steps.bump.outputs.type != ''


### PR DESCRIPTION
## 概要
サプライチェーン攻撃対策として、GitHub ActionsのバージョンタグをコミットSHAに固定。合わせて機能していなかったNuitkaキャッシュを削除。

## 変更内容

- 全アクションのバージョン指定をコミットSHAに固定（タグはコメントで保持）
- 各アクションを最新メジャーバージョンに更新（v4→v6/v7/v8など）
- `actions/cache`によるNuitkaキャッシュを削除（タグpushのみのワークフローでは7日間のキャッシュTTLが切れるため無効）
- 関連する`NUITKA_CACHE_DIR`環境変数も削除

## 確認事項
- [ ] テスト追加・更新済み
- [ ] 動作確認済み