### PR TITLE
fix: pre-push フックが pytest 終了コード5 で失敗する問題を修正

### DIFF
--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -5,7 +5,8 @@ echo "Running ruff check..."
 uv run ruff check .
 
 echo "Running pytest..."
-uv run pytest; exit_code=$?
+exit_code=0
+uv run pytest || exit_code=$?
 [ $exit_code -eq 0 ] || [ $exit_code -eq 5 ] || exit $exit_code
 
 echo "All checks passed."


### PR DESCRIPTION
## 概要

`set -e` が有効な状態で `uv run pytest; exit_code=$?` を実行すると、
pytest がテストなし（終了コード5）で終了した際にシェルが即座に終了し、
`git push` がブロックされていた。

## 変更内容

- `scripts/pre-push`: `uv run pytest; exit_code=$?` を `exit_code=0; uv run pytest || exit_code=$?` に変更

## 確認事項

- [x] 修正後に `git push` が正常に通ることを確認済み

Closes #74