### PR TITLE
fix: インストーラーの発行元をvuchvuに修正

### DIFF
--- a/assets/installer.iss
+++ b/assets/installer.iss
@@ -3,7 +3,7 @@
 [Setup]
 AppName=QR Print Helper
 AppVersion=1.1.0
-AppPublisher=Your Name
+AppPublisher=vuchvu
 AppPublisherURL=https://github.com/vuchvu/qr-print-helper
 DefaultDirName={userdocs}\QR Print Helper
 DefaultGroupName=QR Print Helper


### PR DESCRIPTION
## 概要

インストーラーの発行元が `Your Name` になっていたため、`vuchvu` に修正。closes #72

## 変更内容

- `assets/installer.iss`: `AppPublisher=Your Name` → `AppPublisher=vuchvu`

## 確認事項
- [ ] テスト追加・更新済み
- [x] 動作確認済み