### PR TITLE
fix: リリースノートにchangelogの内容が出力されない問題を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
-          body: ${{ steps.changelog.outputs.changelog }}
+          body: ${{ steps.changelog.outputs.content }}
           files: |
             qr-print-helper-windows/*.zip
             qr-print-helper-macos-arm64/*.zip


### PR DESCRIPTION
## 概要
git-cliff-action の出力変数の誤りにより、リリースノートにchangelogのテキストではなくファイルパス（`git-cliff/CHANGELOG.md`）が表示されていた問題を修正。

## 変更内容

- `outputs.changelog`（ファイルパス）→ `outputs.content`（チェンジログ本文）に変更

## 確認事項
- [ ] テスト追加・更新済み
- [x] 動作確認済み（v1.1.3 リリースでファイルパスが表示されることを確認）